### PR TITLE
Fixed focus on delete

### DIFF
--- a/src/components/Editor/components/TextEditor/index.js
+++ b/src/components/Editor/components/TextEditor/index.js
@@ -1,0 +1,66 @@
+import React from 'react';
+
+const styles = {
+    editor: {
+        width: '98%',
+        maxWidth: '750px',
+        margin: 'auto',
+        padding: '15px'
+    },
+    textarea: {
+        width: '100%',
+        maxWidth: '100%',
+        fontWeight: '300',
+        lineHeight: '2rem',
+        border: 'none',
+        outline: 'none',
+        resize: 'none',
+        padding: '1.5rem',
+        fontSize: '1.5rem'
+    },
+    text: {
+        width: '100%',
+        outline: 'none'
+    }
+};
+
+const TextEditor = ({ actions, height, id, value, focus, index }) => (
+    <textarea
+        rows={1}
+        ref={el => {
+            el && el.scrollHeight !== height ?
+                (actions.update({
+                    id,
+                    index,
+                    height: el.scrollHeight,
+                })) :
+                el
+
+            focus && el
+                ? el.focus()
+                : null
+        }}
+        onChange={e =>
+            e.currentTarget.value ?
+                actions.update({
+                    index,
+                    value: e.currentTarget.value,
+                    height: 0
+                }) :
+                actions.delete({ index })
+        }
+        onKeyDown={e => {
+            if (e.which === 8) {
+                if (!e.currentTarget.value) {
+                    actions.delete({ index })
+                    e.preventDefault()
+                }
+            }
+        }}
+        onFocus={ e => e.currentTarget.selectionStart = e.currentTarget.selectionEnd = e.currentTarget.value.length}
+        style={{ ...styles.textarea, height: `${height}px` }}
+        value={value}
+    ></textarea>
+)
+
+export default TextEditor

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -3,66 +3,21 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { addModule, updateModule, deleteModule } from './actions.js';
 
+import TextEditor from './components/TextEditor/';
+
 const styles = {
     editor: {
         width: '98%',
         maxWidth: '750px',
         margin: 'auto',
         padding: '15px'
-    },
-    textarea: {
-        width: '100%',
-        maxWidth: '100%',
-        fontWeight: '300',
-        lineHeight: '2rem',
-        border: 'none',
-        outline: 'none',
-        resize: 'none',
-        background: '#f4f5f7',
-        padding: '1.5rem',
-        fontSize: '1.5rem'
-    },
-    text: {
-        width: '100%',
-        outline: 'none'
     }
 };
 
 const Editor = ({ modules, actions }) => (
     <div style={styles.editor}>
         {modules.map((module, key) => (
-            <textarea
-                rows={1}
-                ref={el =>
-                    el && el.scrollHeight !== module.height ?
-                        actions.module.update({
-                            id: module.id,
-                            height: el.scrollHeight,
-                        }) :
-                        el
-                }
-                onChange={e =>
-                    e.currentTarget.value ?
-                        actions.module.update({
-                            id: module.id,
-                            value: e.currentTarget.value,
-                            height: 0
-                        }) :
-                        actions.module.delete(module)
-                }
-                onKeyDown={e => {
-                    if (e.which === 8) {
-                        if (!e.currentTarget.value) {
-                            actions.module.update(Object.assign(modules[key - 1], { focus: true }))
-                            actions.module.delete(module)
-                        }
-                    }
-                }}
-                style={{ ...styles.textarea, height: `${module.height}px` }}
-                value={module.value}
-                autoFocus={module.focus ? 'true' : 'false'}
-                key={key}
-            ></textarea>
+            <TextEditor actions={actions.module} {...module} index={key} key={key} />
         ))}
         <p
             onClick={() => actions.module.add({

--- a/src/components/Editor/reducer.js
+++ b/src/components/Editor/reducer.js
@@ -21,27 +21,32 @@ const module = (state = {}, action) => {
                 focus: state.id === action.payload
             }
         case 'UPDATE_MODULE':
-
             return {
                 ...state,
                 ...action.payload,
             }
         case 'DELETE_MODULE':
-            return state.id !== action.payload.id
+            return !(parseInt(state.id, 10) === parseInt(action.payload.id, 10))
     }
 }
 
 const editor = (state = defaultEditorState, action) => {
+    const {
+        index
+    } = action.payload || { index: null }
+
     switch (action.type) {
         case 'FOCUS_MODULE':
-            return state.modules.map(m =>
-                module(m, action)
-            )
+            return state.modules.map((m, i) => (
+                Object.assign(m, {
+                        focus: index === i
+                    })
+            ))
         case 'UPDATE_MODULE':
             return {
                 ...state,
-                modules: state.modules.reduce((mods, m) => {
-                    mods.push(action.payload.hasOwnProperty('id') && m.id === action.payload.id ?
+                modules: state.modules.reduce((mods, m, i) => {
+                    mods.push(index === i ?
                         module(m, action) :
                         m
                     )
@@ -60,11 +65,15 @@ const editor = (state = defaultEditorState, action) => {
                 ]
             }
         case 'DELETE_MODULE':
+            let modules = [...state.modules]
+            modules.splice(index, 1)
+            modules[index - 1] = {
+                ...modules[index - 1],
+                focus: true
+            }
             return {
                 ...state,
-                modules: state.modules.filter(m =>
-                    module(m, action)
-                )
+                modules
             }
         default:
             return state


### PR DESCRIPTION
Given two modules, `Module A` and `Module B`, if `Module B` is deleted, `Module A` takes focus.
This allows a user to quickly begin editing the prior module without having to take the time to manually select it.